### PR TITLE
Add the BIND_CONTRACT_ALIAS event to the ContractEvent enum

### DIFF
--- a/server/src/main/kotlin/io/provenance/objectstore/gateway/eventstream/ContractEvent.kt
+++ b/server/src/main/kotlin/io/provenance/objectstore/gateway/eventstream/ContractEvent.kt
@@ -10,6 +10,7 @@ enum class ContractEvent(val contractName: String, val isHandled: Boolean = fals
     TOGGLE_ASSET_DEFINITION("toggle_asset_definition"),
     ADD_ASSET_VERIFIER("add_asset_verifier"),
     UPDATE_ASSET_VERIFIER("update_asset_verifier"),
+    BIND_CONTRACT_ALIAS("bind_contract_alias"),
     ;
 
     companion object {


### PR DESCRIPTION
Was doing a little testing locally and saw some warns when my local biz was doing bind_contract_alias actions with the contract.  This should fix 'er up.  Almost certainly can wait to make a release for more exciting features